### PR TITLE
Add ipykernel install command to fix issue #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@ pip install tensorflow;
 pip install matplotlib;
 pip install pandas;
 pip install jupyter;
+python -m ipykernel install --user --name=intro_dl
 echo 'done';
 jupyter notebook
 ```
+From within jupyter, in the top-right corner, select the kernel named "intro_dl". This is the kernel that will have the contents of your virtualenv.
+
 ## Conda Instructions
 ```
 git clone https://github.com/yala/introdeeplearning;


### PR DESCRIPTION
Add ipykernel install command to setup instructions. This ensures that jupyter has a kernel that refers to the virtualenv and its modules. Addresses #4 "Lab 1 notebook can't import tensorflow module" for the "Pip instructions" case. We may need a similar change for the Conda case, but I haven't tested that.