### PR TITLE
Typo fix "nonlineanity" -> "nonlinearity"

### DIFF
--- a/Lab1.ipynb
+++ b/Lab1.ipynb
@@ -240,7 +240,7 @@
     "\n",
     "### Building an MLP\n",
     "\n",
-    "MLP or Multi-layer perceptron is a basic archetecture where where we multiply our representation with some matrix `W` and add some bias `b` and then apply some nonlineanity like `tanh` at each layer. Layers are fully connected to the next. As the network gets deeper, it's expressive power grows exponentially and so they can draw some pretty fancy decision boundaries. In this exercise, you'll build your own MLP, with 2 hidden layers (layers that aren't input or output).\n",
+    "MLP or Multi-layer perceptron is a basic archetecture where where we multiply our representation with some matrix `W` and add some bias `b` and then apply some nonlinearity like `tanh` at each layer. Layers are fully connected to the next. As the network gets deeper, it's expressive power grows exponentially and so they can draw some pretty fancy decision boundaries. In this exercise, you'll build your own MLP, with 2 hidden layers (layers that aren't input or output).\n",
     "\n",
     "To make training more stable and efficient, we'll actually evaluate 128 tweets at a time, and take gradients with respect to the loss on the 128. We call this idea **training with mini-batches**.\n",
     "\n",


### PR DESCRIPTION
Fixed typo in Step 4 "Build Computation Graph".